### PR TITLE
Bump SDK to 3.2.1

### DIFF
--- a/typescript-example/ios/Podfile
+++ b/typescript-example/ios/Podfile
@@ -17,10 +17,10 @@ target 'mappedinReactNativeSdkExample' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
+  # use_flipper!
+  # post_install do |installer|
+  #   flipper_post_install(installer)
+  # end
 end
 
 target 'mappedinReactNativeSdkExample-tvOS' do

--- a/typescript-example/ios/Podfile.lock
+++ b/typescript-example/ios/Podfile.lock
@@ -1,7 +1,5 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - CocoaAsyncSocket (7.6.5)
-  - CocoaLibEvent (1.0.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.63.4)
   - FBReactNativeSpec (0.63.4):
@@ -11,52 +9,6 @@ PODS:
     - React-Core (= 0.63.4)
     - React-jsi (= 0.63.4)
     - ReactCommon/turbomodule/core (= 0.63.4)
-  - Flipper (0.54.0):
-    - Flipper-Folly (~> 2.2)
-    - Flipper-RSocket (~> 1.1)
-  - Flipper-DoubleConversion (1.1.7)
-  - Flipper-Folly (2.3.0):
-    - boost-for-react-native
-    - CocoaLibEvent (~> 1.0)
-    - Flipper-DoubleConversion
-    - Flipper-Glog
-    - OpenSSL-Universal (= 1.0.2.20)
-  - Flipper-Glog (0.3.6)
-  - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.1.0):
-    - Flipper-Folly (~> 2.2)
-  - FlipperKit (0.54.0):
-    - FlipperKit/Core (= 0.54.0)
-  - FlipperKit/Core (0.54.0):
-    - Flipper (~> 0.54.0)
-    - FlipperKit/CppBridge
-    - FlipperKit/FBCxxFollyDynamicConvert
-    - FlipperKit/FBDefines
-    - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.54.0):
-    - Flipper (~> 0.54.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.54.0):
-    - Flipper-Folly (~> 2.2)
-  - FlipperKit/FBDefines (0.54.0)
-  - FlipperKit/FKPortForwarding (0.54.0):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.54.0)
-  - FlipperKit/FlipperKitLayoutPlugin (0.54.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutTextSearchable
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.54.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.54.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.54.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.54.0):
-    - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.54.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitNetworkPlugin
   - Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -67,9 +19,6 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - OpenSSL-Universal (1.0.2.20):
-    - OpenSSL-Universal/Static (= 1.0.2.20)
-  - OpenSSL-Universal/Static (1.0.2.20)
   - RCTRequired (0.63.4)
   - RCTTypeSafety (0.63.4):
     - FBLazyVector (= 0.63.4)
@@ -305,32 +254,11 @@ PODS:
   - RNSVG (12.1.0):
     - React
   - Yoga (1.14.0)
-  - YogaKit (1.18.1):
-    - Yoga (~> 1.14)
 
 DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
-  - Flipper (~> 0.54.0)
-  - Flipper-DoubleConversion (= 1.1.7)
-  - Flipper-Folly (~> 2.2)
-  - Flipper-Glog (= 0.3.6)
-  - Flipper-PeerTalk (~> 0.0.4)
-  - Flipper-RSocket (~> 1.1)
-  - FlipperKit (~> 0.54.0)
-  - FlipperKit/Core (~> 0.54.0)
-  - FlipperKit/CppBridge (~> 0.54.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (~> 0.54.0)
-  - FlipperKit/FBDefines (~> 0.54.0)
-  - FlipperKit/FKPortForwarding (~> 0.54.0)
-  - FlipperKit/FlipperKitHighlightOverlay (~> 0.54.0)
-  - FlipperKit/FlipperKitLayoutPlugin (~> 0.54.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (~> 0.54.0)
-  - FlipperKit/FlipperKitNetworkPlugin (~> 0.54.0)
-  - FlipperKit/FlipperKitReactPlugin (~> 0.54.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.54.0)
-  - FlipperKit/SKIOSNetworkPlugin (~> 0.54.0)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -364,17 +292,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
-    - CocoaAsyncSocket
-    - CocoaLibEvent
-    - Flipper
-    - Flipper-DoubleConversion
-    - Flipper-Folly
-    - Flipper-Glog
-    - Flipper-PeerTalk
-    - Flipper-RSocket
-    - FlipperKit
-    - OpenSSL-Universal
-    - YogaKit
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -440,21 +357,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
-  Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
-  Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
-  Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
-  Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
-  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
-  FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   RCTRequired: 082f10cd3f905d6c124597fd1c14f6f2655ff65e
   RCTTypeSafety: 8c9c544ecbf20337d069e4ae7fd9a377aadf504b
   React: b0a957a2c44da4113b0c4c9853d8387f8e64e615
@@ -480,8 +387,7 @@ SPEC CHECKSUMS:
   RNCPicker: 1a266981fc99330c252f5f98b3f09a377a35d88c
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
-  YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: beb179a4025577b4baa2badb84411c64a445ce08
+PODFILE CHECKSUM: 3a03f0eaedee1ef7f7d2b4b9399e75f829a8a009
 
 COCOAPODS: 1.9.1

--- a/typescript-example/ios/mappedinReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/typescript-example/ios/mappedinReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -161,7 +161,6 @@
 				EE17A795F9F7ABC8E7F0101F /* Pods-mappedinReactNativeSdkExample-tvOSTests.debug.xcconfig */,
 				03E4D5E7DC5C474B33140F9C /* Pods-mappedinReactNativeSdkExample-tvOSTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -294,7 +293,9 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = H6C2924QA5;
 						LastSwiftMigration = 1120;
+						ProvisioningStyle = Automatic;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -655,7 +656,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = H6C2924QA5;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = mappedinReactNativeSdkExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -666,6 +670,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = mappedinReactNativeSdkExample;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -678,7 +683,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = H6C2924QA5;
 				INFOPLIST_FILE = mappedinReactNativeSdkExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -688,6 +696,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = mappedinReactNativeSdkExample;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/typescript-example/ios/mappedinReactNativeSdkExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/typescript-example/ios/mappedinReactNativeSdkExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/typescript-example/package.json
+++ b/typescript-example/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@mappedin/react-native-sdk": "^3.1.1",
+    "@mappedin/react-native-sdk": "^3.2.1",
     "@react-native-picker/picker": "^1.9.10",
     "@types/react-native": "^0.63.46",
     "react": "16.13.1",

--- a/typescript-example/src/app.tsx
+++ b/typescript-example/src/app.tsx
@@ -2,12 +2,11 @@ import React from 'react';
 import {Button, SafeAreaView} from 'react-native';
 import type {
   MapViewStore,
-  IMappedinLocation,
-  IMappedin,
-  IMappedinMap,
-  TMappedinDirections,
+  Mappedin,
+  MappedinMap,
+  MappedinDirections,
   TMiMapViewOptions,
-  IMappedinNode,
+  MappedinNode,
   MappedinLocation,
   MappedinPolygon,
 } from '@mappedin/react-native-sdk';
@@ -33,30 +32,30 @@ export enum APPSTATE {
 
 const useRootContext = () => {
   const [selectedMapId, setSelectedMapId] = React.useState<
-    IMappedinMap['id']
+    MappedinMap['id']
   >();
-  const [venueData, setVenue] = React.useState<IMappedin>();
+  const [venueData, setVenue] = React.useState<Mappedin>();
   const [
     selectedLocation,
     setSelectedLocation,
-  ] = React.useState<IMappedinLocation>();
+  ] = React.useState<MappedinLocation>();
   const mapView = React.useRef<MapViewStore>();
-  const [directions, setDirections] = React.useState<TMappedinDirections>();
+  const [directions, setDirections] = React.useState<MappedinDirections>();
   const [loading, setLoading] = React.useState<boolean>(true);
   const [
     nearestLocation,
     setNearestLocation,
-  ] = React.useState<IMappedinLocation>();
+  ] = React.useState<MappedinLocation>();
   const [currentLevel, setCurrentLevel] = React.useState<
-    IMappedinMap['name']
+    MappedinMap['name']
   >();
 
   const [appState, setAppState] = React.useState<APPSTATE>(APPSTATE.HOME);
   const [departure, setDeparture] = React.useState<
-    IMappedinLocation | IMappedinNode
+    MappedinLocation | MappedinNode
   >();
   const [destination, setDestination] = React.useState<
-    IMappedinLocation | IMappedinNode
+    MappedinLocation | MappedinNode
   >();
   const [mapState, setMapState] = React.useState<STATE>(STATE.EXPLORE);
   const [mapDimensions, setMapDimensions] = React.useState({
@@ -112,24 +111,24 @@ const useRootContext = () => {
 
 export interface IRootContext {
   appState: APPSTATE;
-  departure: IMappedinLocation | IMappedinNode | undefined;
+  departure: MappedinLocation | MappedinNode | undefined;
   setDeparture: React.Dispatch<
-    React.SetStateAction<IMappedinLocation | IMappedinNode | undefined>
+    React.SetStateAction<MappedinLocation | MappedinNode | undefined>
   >;
   distancePoints: [MappedinPolygon | null, MappedinPolygon | null];
   setDistancePoints: React.Dispatch<
     React.SetStateAction<[MappedinPolygon | null, MappedinPolygon | null]>
   >;
-  destination: IMappedinLocation | IMappedinNode | undefined;
+  destination: MappedinLocation | MappedinNode | undefined;
   setDestination: React.Dispatch<
-    React.SetStateAction<IMappedinLocation | IMappedinNode | undefined>
+    React.SetStateAction<MappedinLocation | MappedinNode | undefined>
   >;
   setAppState: React.Dispatch<React.SetStateAction<APPSTATE>>;
-  nearestLocation: IMappedinLocation | undefined;
-  directions: TMappedinDirections | undefined;
+  nearestLocation: MappedinLocation | undefined;
+  directions: MappedinDirections | undefined;
   mapView: React.MutableRefObject<MapViewStore | undefined>;
   selectedMapId: string | undefined;
-  venueData: IMappedin | undefined;
+  venueData: Mappedin | undefined;
   selectedLocation: MappedinLocation | undefined;
   loading: boolean;
   reset: () => void;
@@ -140,21 +139,21 @@ export interface IRootContext {
   mapState: STATE;
   setMapState: React.Dispatch<React.SetStateAction<STATE>>;
   options: React.MutableRefObject<TMiMapViewOptions>;
-  currentLevel: IMappedinMap['name'] | undefined;
+  currentLevel: MappedinMap['name'] | undefined;
   setCurrentLevel: React.Dispatch<
-    React.SetStateAction<IMappedinMap['name'] | undefined>
+    React.SetStateAction<MappedinMap['name'] | undefined>
   >;
   setNearestLocation: React.Dispatch<
-    React.SetStateAction<IMappedinLocation | undefined>
+    React.SetStateAction<MappedinLocation | undefined>
   >;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setDirections: React.Dispatch<
-    React.SetStateAction<TMappedinDirections | undefined>
+    React.SetStateAction<MappedinDirections | undefined>
   >;
   setSelectedMapId: React.Dispatch<React.SetStateAction<string | undefined>>;
-  setVenue: React.Dispatch<React.SetStateAction<IMappedin | undefined>>;
+  setVenue: React.Dispatch<React.SetStateAction<Mappedin | undefined>>;
   setSelectedLocation: React.Dispatch<
-    React.SetStateAction<IMappedinLocation | undefined>
+    React.SetStateAction<MappedinLocation | undefined>
   >;
 }
 

--- a/typescript-example/src/directions-card.tsx
+++ b/typescript-example/src/directions-card.tsx
@@ -1,8 +1,6 @@
 import React, {useContext, useEffect} from 'react';
 import {Button, Dimensions, Text, TouchableOpacity, View} from 'react-native';
 import {
-  IMappedinLocation,
-  IMappedinNode,
   MappedinLocation,
   MappedinNode,
 } from '@mappedin/react-native-sdk';
@@ -20,7 +18,7 @@ const LocationsPickerModal = ({
   locations,
   locationIdSelected,
 }: {
-  locations: IMappedinLocation[];
+  locations: MappedinLocation[];
   locationIdSelected: (id: string) => void;
 }) => {
   if (locations == null || locations.length === 0) {
@@ -377,13 +375,13 @@ export const Directions = () => {
               {
                 id: '-1',
                 name: 'Please select a location',
-              } as IMappedinLocation,
+              } as MappedinLocation,
               nearestLocation != null && {
                 id: nearestLocation?.id,
                 name: `[Your Location]${nearestLocation?.name}`,
               },
               ...venueData.locations,
-            ].filter((x) => x) as IMappedinLocation[]
+            ].filter((x) => x) as MappedinLocation[]
           }
           locationIdSelected={(locationId) => {
             if (editing === FIELD.DEPARTURE) {

--- a/typescript-example/src/location-card.tsx
+++ b/typescript-example/src/location-card.tsx
@@ -84,7 +84,9 @@ export const LocationCard = () => {
           if (nearestLocation != null) {
             setDeparture(nearestLocation.clone());
           }
-          setDestination(selectedLocation.clone());
+          if (selectedLocation != null) {
+            setDestination(selectedLocation.clone());
+          }
         }}></Button>
     </Card>
   );

--- a/typescript-example/src/map-picker.tsx
+++ b/typescript-example/src/map-picker.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import type { IMappedinMap } from '@mappedin/react-native-sdk';
+import type { MappedinMap } from '@mappedin/react-native-sdk';
 import { Picker } from '@react-native-picker/picker';
 import { RootContext } from './app';
 
@@ -32,7 +32,7 @@ export const MapPicker = () => {
         right: 10,
       }}
       onValueChange={(itemValue) => {
-        mapView.current?.setMap(itemValue as IMappedinMap['id']);
+        mapView.current?.setMap(itemValue as MappedinMap['id']);
       }}
     >
       {venueData.maps.map((m) => (

--- a/typescript-example/src/map.tsx
+++ b/typescript-example/src/map.tsx
@@ -93,7 +93,7 @@ export const Map = ({options}: {options: TMiMapViewOptions}) => {
           setMapState(state);
         }}
         options={options}
-        onBlueDotUpdated={({update}) => {
+        onBlueDotPositionUpdated={({update}) => {
           const nearestNode = update.nearestNode;
           if (nearestNode != null) {
             const primaryLocation = nearestNode.locations[0];

--- a/typescript-example/yarn.lock
+++ b/typescript-example/yarn.lock
@@ -1023,10 +1023,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mappedin/react-native-sdk@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@mappedin/react-native-sdk/-/react-native-sdk-3.1.1.tgz#5b276fe915e5e6bc8b13599e91aa72a66b455bd9"
-  integrity sha512-VJCtwXle1gGsCaVzX66ReT8LDRXM7VmMyBUc+eEzGHEXWPg1c+KMbJ3h292Tp2uO3q4c/TeZtS/k6Kh7URPBKg==
+"@mappedin/react-native-sdk@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/@mappedin/react-native-sdk/-/react-native-sdk-3.2.1.tgz#5e7b495f3d915840493e26bad1d495eebbfc9dc7"
+  integrity sha512-iG7lWNw4MLRTeIORlwcuhbqGCj7BfRPz2DttTIMIyYid4Yfdx1nywBwHiBawDhSgxGxiDxxbkFDf32rQWcsAKQ==
 
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"


### PR DESCRIPTION
- Commented out flipper as builds were failing when targeting iOS 14.5
- Bumped SDK to v3.2.1 and moved over to new BlueDot API
- Moved over to using implicit interfaces instead of explicit