### PR TITLE
Bump Android SDK minimum version to 21

### DIFF
--- a/typescript-example/android/build.gradle
+++ b/typescript-example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }


### PR DESCRIPTION
# Purpose
Bump Android SDK minimum version to 21 (Android 5). This was required by a dependency.

# Expected Results
Bump Android SDK minimum version to 21

# Testing Notes

<!-- REQUIRED -->
<!-- If manual testing is required, add a list of test cases you want QA to check. You can also add notes on what systems were touched to help with exploratory testing. -->

- none 

# Security Impact

<!-- REQUIRED -->
<!-- Does this change impact security in any way? For example, authentication, authorization, network configuration, etc. If so, please describe the implications, and add Security Team as a reviewer. -->

- [x] No, this change does not have any security implications
- [ ] Yes. ( **Requires review from @MappedIn/security-team** )  
      Impact: [Description]

# DevOps Impact

<!-- REQUIRED -->
<!-- Does this change require a change to a config file or environment variable? New storage buckets? Node version change? Networking changes? If so, please describe what needs to change, and include DevOps as a reviewer -->
<!-- If you check yes, your PR CANNOT be merged until the environment is changed in both staging AND production, so the new setup MUST be backwards compatible with the current release -->

- [x] No, this change does not require DevOps assistance to be deployed in production
- [ ] Yes. ( **Requires review from @MappedIn/DevOps** )  
      Changes: [List of changes required with a description of each, including exact names of env/config variables]
