### PR TITLE
Add v5 labels example and bump version

### DIFF
--- a/SDKv5_Examples/PlaygroundSamples/src/App.tsx
+++ b/SDKv5_Examples/PlaygroundSamples/src/App.tsx
@@ -36,12 +36,14 @@ import Markers from './examples/Markers';
 import RenderMap from './examples/RenderMap';
 import Search from './examples/Search';
 import Tooltips from './examples/Tooltips';
+import Labels from './examples/Labels';
 import TurnByTurnDirections from './examples/TurnByTurnDirections';
 
 export type RootStackParams = {
   Home: undefined;
   'Add interactivity': undefined;
   'Render map': undefined;
+  Labels: undefined;
   Markers: undefined;
   Tooltips: undefined;
   'Level selector': undefined;
@@ -93,6 +95,11 @@ const BasicView = ({
             onPress={() => navigation.navigate('Add interactivity')}>
             Make locations clickable with{' '}
             <Text style={styles.inlineCode}>onClick</Text> -callback
+          </ExampleLink>
+          <ExampleLink
+            title="Labels"
+            onPress={() => navigation.navigate('Labels')}>
+            Adding Flat or Floating Labels to your locations
           </ExampleLink>
           <ExampleLink
             title="Markers"
@@ -168,6 +175,11 @@ const App = () => {
           name="Add interactivity"
           component={AddInteractivity}
           options={{title: 'Adding interactivity'}}
+        />
+        <Stack.Screen
+          name="Labels"
+          component={Labels}
+          options={{title: 'Labels'}}
         />
         <Stack.Screen
           name="Markers"

--- a/SDKv5_Examples/PlaygroundSamples/src/examples/Labels.tsx
+++ b/SDKv5_Examples/PlaygroundSamples/src/examples/Labels.tsx
@@ -40,7 +40,10 @@ const labelTypes = [
 
 const Labels = () => {
   const mapView = useRef<MapViewStore>(null);
-  const [selectedLabelType, setSelectedLabelType] = useState<number>(0);
+  const [selectedLabelType, setSelectedLabelType] = useState<string>(
+    labelTypes[0],
+  );
+
   const LabelPicker = () => {
     return (
       <Picker
@@ -50,15 +53,15 @@ const Labels = () => {
           setSelectedLabelType(labelType);
 
           switch (labelType) {
-            case 0:
+            case labelTypes[0]:
               mapView.current?.FlatLabels.removeAll();
               mapView.current?.FloatingLabels.removeAll();
               mapView.current?.FloatingLabels.labelAllLocations();
               break;
-            case 1:
+            case labelTypes[1]:
               mapView.current?.FlatLabels.removeAll();
               mapView.current?.FloatingLabels.removeAll();
-              mapView.current?.venueData.categories.forEach(
+              mapView.current?.venueData?.categories.forEach(
                 (category: MappedinCategory, index: number) => {
                   category.locations.forEach((location: MappedinLocation) => {
                     if (location.polygons.length <= 0) {
@@ -84,18 +87,18 @@ const Labels = () => {
                 },
               );
               break;
-            case 2:
+            case labelTypes[2]:
               mapView.current?.FlatLabels.removeAll();
               mapView.current?.FloatingLabels.removeAll();
               mapView.current?.FlatLabels.labelAllLocations();
               break;
-            case 3:
+            case labelTypes[3]:
               mapView.current?.FlatLabels.removeAll();
               mapView.current?.FloatingLabels.removeAll();
               mapView.current?.FlatLabels.labelAllLocations({
                 appearance: {
                   font: 'Georgia',
-                  fontSize: 16,
+                  fontSize: 14,
                   color: '#1c1c43',
                 },
               });
@@ -105,7 +108,7 @@ const Labels = () => {
           }
         }}>
         {labelTypes.map((labelType, index) => (
-          <Picker.Item key={index} label={labelType} value={index} />
+          <Picker.Item key={index} label={labelType} value={labelType} />
         ))}
       </Picker>
     );

--- a/SDKv5_Examples/PlaygroundSamples/src/examples/Labels.tsx
+++ b/SDKv5_Examples/PlaygroundSamples/src/examples/Labels.tsx
@@ -1,0 +1,136 @@
+import {
+  MappedinCategory,
+  MappedinLocation,
+  MapViewStore,
+  MiMapView,
+  TGetVenueOptions,
+} from '@mappedin/react-native-sdk';
+import {Picker} from '@react-native-picker/picker';
+import React, {useRef, useState} from 'react';
+import {SafeAreaView, StyleSheet} from 'react-native';
+
+// See Trial API key Terms and Conditions
+// https://developer.mappedin.com/api-keys/
+const venueOptions: TGetVenueOptions = {
+  venue: 'mappedin-demo-mall',
+  clientId: '5eab30aa91b055001a68e996',
+  clientSecret: 'RJyRXKcryCMy4erZqqCbuB1NbR66QTGNXVE0x3Pg6oCIlUR1',
+};
+
+const icon = `<svg width="92" height="92" viewBox="-17 0 92 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <g clip-path="url(#clip0)">
+            <path d="M53.99 28.0973H44.3274C41.8873 28.0973 40.7161 29.1789 40.7161 31.5387V61.1837L21.0491 30.7029C19.6827 28.5889 18.8042 28.1956 16.0714 28.0973H6.5551C4.01742 28.0973 2.84619 29.1789 2.84619 31.5387V87.8299C2.84619 90.1897 4.01742 91.2712 6.5551 91.2712H16.2178C18.7554 91.2712 19.9267 90.1897 19.9267 87.8299V58.3323L39.6912 88.6656C41.1553 90.878 41.9361 91.2712 44.669 91.2712H54.0388C56.5765 91.2712 57.7477 90.1897 57.7477 87.8299V31.5387C57.6501 29.1789 56.4789 28.0973 53.99 28.0973Z" fill="white"/>
+            <path d="M11.3863 21.7061C17.2618 21.7061 22.025 16.9078 22.025 10.9887C22.025 5.06961 17.2618 0.27124 11.3863 0.27124C5.51067 0.27124 0.747559 5.06961 0.747559 10.9887C0.747559 16.9078 5.51067 21.7061 11.3863 21.7061Z" fill="white"/>
+            </g>
+            <defs>
+            <clipPath id="clip0">
+            <rect width="57" height="91" fill="white" transform="translate(0.747559 0.27124)"/>
+            </clipPath>
+            </defs>
+            </svg>`;
+
+const colors = ['dodgerblue', 'pink', 'green', 'orange', 'tomato', 'gray'];
+
+const labelTypes = [
+  'Default Floating Labels',
+  'Custom Floating Labels',
+  'Default Flat Labels',
+  'Custom Flat Labels',
+];
+
+const Labels = () => {
+  const mapView = useRef<MapViewStore>(null);
+  const [selectedLabelType, setSelectedLabelType] = useState<number>(0);
+  const LabelPicker = () => {
+    return (
+      <Picker
+        mode="dropdown"
+        selectedValue={selectedLabelType}
+        onValueChange={async labelType => {
+          setSelectedLabelType(labelType);
+
+          switch (labelType) {
+            case 0:
+              mapView.current?.FlatLabels.removeAll();
+              mapView.current?.FloatingLabels.removeAll();
+              mapView.current?.FloatingLabels.labelAllLocations();
+              break;
+            case 1:
+              mapView.current?.FlatLabels.removeAll();
+              mapView.current?.FloatingLabels.removeAll();
+              mapView.current?.venueData.categories.forEach(
+                (category: MappedinCategory, index: number) => {
+                  category.locations.forEach((location: MappedinLocation) => {
+                    if (location.polygons.length <= 0) {
+                      return;
+                    }
+                    const color = colors[index % colors.length];
+                    mapView.current?.FloatingLabels.add(
+                      location.polygons[0],
+                      location.name,
+                      {
+                        appearance: {
+                          marker: {
+                            icon: icon,
+                            foregroundColor: {
+                              active: color,
+                              inactive: color,
+                            },
+                          },
+                        },
+                      },
+                    );
+                  });
+                },
+              );
+              break;
+            case 2:
+              mapView.current?.FlatLabels.removeAll();
+              mapView.current?.FloatingLabels.removeAll();
+              mapView.current?.FlatLabels.labelAllLocations();
+              break;
+            case 3:
+              mapView.current?.FlatLabels.removeAll();
+              mapView.current?.FloatingLabels.removeAll();
+              mapView.current?.FlatLabels.labelAllLocations({
+                appearance: {
+                  font: 'Georgia',
+                  fontSize: 16,
+                  color: '#1c1c43',
+                },
+              });
+              break;
+            default:
+              break;
+          }
+        }}>
+        {labelTypes.map((labelType, index) => (
+          <Picker.Item key={index} label={labelType} value={index} />
+        ))}
+      </Picker>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.fullSafeAreaView}>
+      <LabelPicker />
+      <MiMapView
+        style={styles.mapView}
+        key="mappedin"
+        ref={mapView}
+        options={venueOptions}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  fullSafeAreaView: {
+    flex: 1,
+  },
+  mapView: {
+    flex: 1,
+  },
+});
+
+export default Labels;

--- a/SDKv5_Examples/PlaygroundSamples/yarn.lock
+++ b/SDKv5_Examples/PlaygroundSamples/yarn.lock
@@ -1059,9 +1059,9 @@
     "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@mappedin/react-native-sdk@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@mappedin/react-native-sdk/-/react-native-sdk-5.0.3.tgz#48ef24f6b133550a5815117213f128e7c2e28814"
-  integrity sha512-NnU18bhppic/LkIwCtXLUK2OE5MtxZaoBsncgCuxdOGxCdbm2ag2HCFGAcC+a/qgKdKx1vkhXDCltBoPo8jN0Q==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@mappedin/react-native-sdk/-/react-native-sdk-5.1.2.tgz#27260e1a358dd12b4e14f0f9703435f6f5632437"
+  integrity sha512-lktZqmR+gGc5WpA0e/3P810b/t8IXW83AsCOiRvFu0D65I6yF/Izf2R2x1ywKWpM4izUnPesQlfrfvX4hiqXpQ==
   dependencies:
     react-native-webview "^11.13.0"
 
@@ -5772,7 +5772,15 @@ react-native-screens@^3.18.2:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native-webview@^11.13.0, react-native-webview@^11.26.0:
+react-native-webview@^11.13.0:
+  version "11.26.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.26.1.tgz#658c09ed5162dc170b361e48c2dd26c9712879da"
+  integrity sha512-hC7BkxOpf+z0UKhxFSFTPAM4shQzYmZHoELa6/8a/MspcjEP7ukYKpuSUTLDywQditT8yI9idfcKvfZDKQExGw==
+  dependencies:
+    escape-string-regexp "2.0.0"
+    invariant "2.2.4"
+
+react-native-webview@^11.26.0:
   version "11.26.0"
   resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.26.0.tgz#e524992876fe4a79e69905f0fab8949b470e9f16"
   integrity sha512-4T4CKRm8xlaQDz9h/bCMPGAvtkesrhkRWqCX9FDJEzBToaVUIsV0ZOqtC4w/JSnCtFKKYiaC1ReJtCGv+4mFeQ==

--- a/SDKv5_Examples/PlaygroundSamples/yarn.lock
+++ b/SDKv5_Examples/PlaygroundSamples/yarn.lock
@@ -1060,7 +1060,7 @@
 
 "@mappedin/react-native-sdk@^5.0.3":
   version "5.1.5"
-  resolved "https://npm.pkg.github.com/download/@MappedIn/react-native-sdk/5.1.5/4591c749160d7f8bfc0841e5f08321f15af4a916#4591c749160d7f8bfc0841e5f08321f15af4a916"
+  resolved "https://registry.yarnpkg.com/@mappedin/react-native-sdk/-/react-native-sdk-5.1.5.tgz#4591c749160d7f8bfc0841e5f08321f15af4a916"
   integrity sha512-zgAxJ0wEu8qkIA+mMtLDut0JGuUBNcRziaZRwYlndYrbNu+hKrQGzP1CppMNOM0sTBrv+fXzboRH3dX7hywCNw==
   dependencies:
     react-native-webview "^11.13.0"

--- a/SDKv5_Examples/PlaygroundSamples/yarn.lock
+++ b/SDKv5_Examples/PlaygroundSamples/yarn.lock
@@ -1059,9 +1059,9 @@
     "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@mappedin/react-native-sdk@^5.0.3":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@mappedin/react-native-sdk/-/react-native-sdk-5.1.2.tgz#27260e1a358dd12b4e14f0f9703435f6f5632437"
-  integrity sha512-lktZqmR+gGc5WpA0e/3P810b/t8IXW83AsCOiRvFu0D65I6yF/Izf2R2x1ywKWpM4izUnPesQlfrfvX4hiqXpQ==
+  version "5.1.5"
+  resolved "https://npm.pkg.github.com/download/@MappedIn/react-native-sdk/5.1.5/4591c749160d7f8bfc0841e5f08321f15af4a916#4591c749160d7f8bfc0841e5f08321f15af4a916"
+  integrity sha512-zgAxJ0wEu8qkIA+mMtLDut0JGuUBNcRziaZRwYlndYrbNu+hKrQGzP1CppMNOM0sTBrv+fXzboRH3dX7hywCNw==
   dependencies:
     react-native-webview "^11.13.0"
 


### PR DESCRIPTION
- Adds example for default and custom Floating Labels and Flat Labels.
- Bumps `@mappedin/react-native-sdk` to v5.1.5
![Screenshot 2023-02-15 at 9 21 27 AM](https://user-images.githubusercontent.com/6911696/219053522-1fde6f36-8eef-41d9-9940-960daac96612.png)
